### PR TITLE
Fix "same as ..." checkbox title for double datetime picker.

### DIFF
--- a/src/DateRangePicker/Internal/View.elm
+++ b/src/DateRangePicker/Internal/View.elm
@@ -194,7 +194,7 @@ doubleClockView (Model { range, timePickers, viewType }) =
                     , Html.map RangeStartPickerMsg (TimePicker.view startPicker)
                     , div [ class "checkbox", onClick ToggleTimeMirroring ]
                         [ Icons.checkbox (Icons.Size "16" "16") mirrorTimes
-                        , span [ class "text" ] [ text ("Same as " ++ String.toLower pickerTitles.end) ]
+                        , span [ class "text" ] [ text ("Same as " ++ String.toLower pickerTitles.start) ]
                         ]
                     ]
                 , div [ class "time-picker-container no-select" ]


### PR DESCRIPTION
Hi Panos :) 
This pull request is to fix the following issue we've found.

https://github.com/PanagiotisGeorgiadis/Elm-DatePicker/blob/master/screenshots/Double-DateTime-RangePicker-2.png

Steps to redproduce:
1. Open double datetime picker, as on the screenshot above.
2. Uncheck "same as..." checkbox.
3. Select different time.
4. Check the checkbox.

**Result**: the time is set as **pick-up** time, which is on the left. But the checkbox says "same as **drop-off** time".
**Expected result**: the checkbox title should corresponds with the functionality it does.