### PR TITLE
Proof of concept for custom date validators

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -121,6 +121,13 @@ validatePrimaryDate { today, primaryDate, dateLimit } =
             else
                 minDate
 
+        Custom isValid ->
+            if isValid date today then
+                date
+
+            else
+                today
+
         NoLimit ->
             date
 

--- a/src/DatePicker/Internal/View.elm
+++ b/src/DatePicker/Internal/View.elm
@@ -60,6 +60,12 @@ singleCalendarView ((Model { today, primaryDate, dateLimit, i18n }) as model) =
                     , compareYearMonth minDate today == LT && compareYearMonth maxDate today == GT
                     )
 
+                Custom isDisabledDate ->
+                    ( True
+                    , True
+                    , not <| isDisabledDate today today
+                    )
+
                 NoLimit ->
                     ( True
                     , True
@@ -99,6 +105,12 @@ doubleCalendarView ((Model { today, primaryDate, dateLimit, i18n }) as model) =
                     , compareYearMonth maxDate nextDate == GT
                       -- If today is not in the DateRange we shouldn't render the Today button.
                     , compareYearMonth minDate today == LT && compareYearMonth maxDate today == GT
+                    )
+
+                Custom isDisabledDate ->
+                    ( True
+                    , True
+                    , not <| isDisabledDate today today
                     )
 
                 NoLimit ->
@@ -259,10 +271,13 @@ dateHtml ((Model { today, selectedDate, i18n }) as model) date =
 
 -}
 checkIfDisabled : Model -> DateTime -> Bool
-checkIfDisabled (Model { dateLimit }) date =
+checkIfDisabled (Model { dateLimit, today }) date =
     case dateLimit of
         NoLimit ->
             False
+
+        Custom isDisabledDate ->
+            isDisabledDate date today
 
         DateLimit { minDate, maxDate } ->
             let

--- a/src/DatePicker/Types.elm
+++ b/src/DatePicker/Types.elm
@@ -73,6 +73,7 @@ on the repository of this package.
 -}
 type DateLimit
     = DateLimit { minDate : DateTime, maxDate : DateTime }
+    | Custom (DateTime -> DateTime -> Bool)
     | NoLimit
 
 


### PR DESCRIPTION
I have a need using Elm-DatePicker for more complex logic on which dates are disabled. In this particular case I need to limit enabled dates to weekdays in the future and just how far in the future depends on the current time of day. 

I considered an extension to Elm-DateTime that might allow mixing rule sets such as `DateLimit { minDate, maxDate }`
along with something like `WeekdayLimit (List Time.Weekday)`, but my requirement depending on the current time of day makes a more declarative style difficult at best to specify cleanly. I believe it is also common in calendar widgets to allow a custom function for providing valid date rules. 

This PR is a proof of concept of how to add a custom validator function controlling which dates are disabled. If the overall approach is acceptable it would still need to be ported to `DateRangePicker` as well as documents and comments updated. 